### PR TITLE
Chore: npm error fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "eslint": "^8",
+        "eslint": "^8.57.0",
         "eslint-config-next": "14.2.4",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
@@ -1686,6 +1686,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "^8",
+    "eslint": "^8.57.0",
     "eslint-config-next": "14.2.4",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",


### PR DESCRIPTION
## 해결내용
closes #17 

- npm dependency vs peer dependency version이 맞지 않아서 생기는 에러를 해결하였습니다.
### 에러 내용
![image](https://github.com/user-attachments/assets/94f0acaf-dee1-4593-9d12-66598ec6235c)

- 로컬에서 `npm install --force`로 진행하면 됩니다만, vercel에서도 똑같은 에러가 발생했습니다.
   따라서 vercel에서도 똑같이 명령어를 변경하였습니다.
   
![image](https://github.com/user-attachments/assets/b5e3c999-2441-43e4-92bc-4017e510fbcf)


## 추가 내용
배포를 진행하며 vercel에 env 파일을 등록하는데, KEY Prefix를 쓰지 않는게 보안에 좋다고 하여, .env.local의 모든 env파일을 삭제했습니다 반영 부탁합니다 @sjg729729 

![image](https://github.com/user-attachments/assets/5e9d8176-8b98-44f9-b07b-6ad52467090b)
