### PR TITLE
feat: 프로필, 비밀번호 변경 페이지 완성

### DIFF
--- a/app/(route)/(header)/(auth)/login/email/page.tsx
+++ b/app/(route)/(header)/(auth)/login/email/page.tsx
@@ -57,10 +57,13 @@ const EmailLoginPage = ({}: EmailLoginPageProps): ReactNode => {
     setIsShow(!isShow)
   }
 
-  const passwordEye = isShow ? (
-    <LucideIcon name='EyeOff' onClick={onClickEye} className='absolute right-2 h-full opacity-40' size={24} />
-  ) : (
-    <LucideIcon name='Eye' onClick={onClickEye} className='absolute right-2 h-full opacity-40' size={24} />
+  const passwordEye = (
+    <LucideIcon
+      name={!isShow ? 'EyeOff' : 'Eye'}
+      onClick={!isShow ? onClickEye : onClickEye}
+      className='absolute right-2 h-full opacity-40'
+      size={24}
+    />
   )
 
   return (

--- a/app/(route)/(header)/(auth)/login/page.tsx
+++ b/app/(route)/(header)/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { Mail } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { signIn, useSession } from 'next-auth/react'
+import { signIn } from 'next-auth/react'
 import React, { ReactNode } from 'react'
 
 import { TextDivider } from '@/components/common/Dividers'
@@ -45,9 +45,6 @@ const LOGIN_BUTTONS: Array<SocialLoginButton> = [
 ]
 
 const LoginPage = (): ReactNode => {
-  const session = useSession()
-  console.log(session)
-
   const router = useRouter()
 
   const onClickLoginBtn = async (provider: string): Promise<void> => {

--- a/app/(route)/(header)/(auth)/signout/page.tsx
+++ b/app/(route)/(header)/(auth)/signout/page.tsx
@@ -1,0 +1,9 @@
+import React, { ReactNode } from 'react'
+
+interface SignOutPageProps {}
+
+const SignOutPage = ({}: SignOutPageProps): ReactNode => {
+  return <div>SignOutPage</div>
+}
+
+export default SignOutPage

--- a/app/(route)/(header)/main/info/page.tsx
+++ b/app/(route)/(header)/main/info/page.tsx
@@ -1,9 +1,25 @@
 import React, { ReactNode } from 'react'
 
+import { auth } from '@/auth'
+import ProfileChange from '@/components/main/ProfileChange'
+import { UserInfo } from '@/lib/types/Session'
+
 interface MainInfoPageProps {}
 
-const MainInfoPage = ({}: MainInfoPageProps): ReactNode => {
-  return <div>MainInfoPage</div>
+const MainInfoPage = async ({}: MainInfoPageProps): Promise<ReactNode> => {
+  const s: any = await auth()
+  console.log(s)
+
+  const session: UserInfo = {
+    email: s.user.email,
+    accessToken: s.user.accessToken,
+    provider: s.user.provider,
+    status_message: s.user.status_message,
+    image: s.user.image,
+    nickname: s.user.nickname,
+  }
+
+  return <ProfileChange session={session} />
 }
 
 export default MainInfoPage

--- a/app/(route)/(header)/main/info/page.tsx
+++ b/app/(route)/(header)/main/info/page.tsx
@@ -8,7 +8,6 @@ interface MainInfoPageProps {}
 
 const MainInfoPage = async ({}: MainInfoPageProps): Promise<ReactNode> => {
   const s: any = await auth()
-  console.log(s)
 
   const session: UserInfo = {
     email: s.user.email,

--- a/app/(route)/(header)/main/layout.tsx
+++ b/app/(route)/(header)/main/layout.tsx
@@ -1,15 +1,18 @@
 import React, { ReactNode } from 'react'
 
+import { auth } from '@/auth'
 import SideBar from '@/components/main/SideBar'
 
 interface MainLayoutProps {
   children: React.ReactNode
 }
 
-const MainLayout = ({ children }: MainLayoutProps): ReactNode => {
+const MainLayout = async ({ children }: MainLayoutProps): Promise<ReactNode> => {
+  const s: any = await auth()
+
   return (
-    <main className='flex h-min w-dvw bg-tbSecondary pt-24'>
-      <SideBar />
+    <main className='flex min-h-screen w-dvw bg-tbSecondary pt-24'>
+      <SideBar isCredentails={s.user.provider === 'credentials'} />
       {children}
     </main>
   )

--- a/app/(route)/(header)/main/layout.tsx
+++ b/app/(route)/(header)/main/layout.tsx
@@ -12,7 +12,12 @@ const MainLayout = async ({ children }: MainLayoutProps): Promise<ReactNode> => 
 
   return (
     <main className='flex min-h-screen w-dvw bg-tbSecondary pt-24'>
-      <SideBar isCredentails={s.user.provider === 'credentials'} />
+      <SideBar
+        isCredentails={s.user.provider === 'credentials'}
+        image={s.user.image}
+        status_message={s.user.status_message}
+        nickname={s.user.nickname}
+      />
       {children}
     </main>
   )

--- a/app/(route)/(header)/main/password/page.tsx
+++ b/app/(route)/(header)/main/password/page.tsx
@@ -84,8 +84,6 @@ const ChangePasswordPage = ({}: ChangePasswordPageProps): ReactNode => {
       })
 
       const status = res.status
-      const data = await res.json()
-      console.log(data)
 
       switch (status) {
         case 200:
@@ -191,7 +189,10 @@ const ChangePasswordPage = ({}: ChangePasswordPageProps): ReactNode => {
 
       <div className='my-3 flex flex-col text-center text-sm text-[#817A7A] md:block'>
         더 이상 TRABOOK과 함께하고 싶지 않으신가요?
-        <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
+        <Link
+          href={ROUTES.AUTH.SIGNOUT.url}
+          className='mx-5 text-black underline hover:cursor-pointer hover:text-tbBlue'
+        >
           회원 탈퇴
         </Link>
       </div>

--- a/app/(route)/(header)/main/password/page.tsx
+++ b/app/(route)/(header)/main/password/page.tsx
@@ -189,7 +189,7 @@ const ChangePasswordPage = ({}: ChangePasswordPageProps): ReactNode => {
         </Button>
       </div>
 
-      <div className='my-3 flex flex-col text-center text-[#817A7A] md:block'>
+      <div className='my-3 flex flex-col text-center text-sm text-[#817A7A] md:block'>
         더 이상 TRABOOK과 함께하고 싶지 않으신가요?
         <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
           회원 탈퇴

--- a/app/(route)/(header)/main/password/page.tsx
+++ b/app/(route)/(header)/main/password/page.tsx
@@ -1,9 +1,202 @@
-import React, { ReactNode } from 'react'
+'use client'
+
+import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import React, { ChangeEventHandler, Dispatch, ReactNode, SetStateAction, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { BACKEND_ROUTES, ROUTES } from '@/lib/constants/routes'
+import LucideIcon from '@/lib/icons/LucideIcon'
+import { cn } from '@/lib/utils/cn'
+
+type PasswordState = {
+  password: string
+  isShow: boolean
+}
 
 interface ChangePasswordPageProps {}
 
+function isValidPassword(password: string) {
+  const hasLetter = /[a-zA-Z]/.test(password)
+  const hasNumber = /\d/.test(password)
+  const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password)
+  const length = password.trim().length >= 10 ? true : false
+
+  return hasLetter && hasNumber && hasSpecialChar && length
+}
+
 const ChangePasswordPage = ({}: ChangePasswordPageProps): ReactNode => {
-  return <div className='w-full bg-white'>ChangePasswordPage</div>
+  const [currentPw, setCurrentPw] = useState<PasswordState>({ password: '', isShow: false })
+  const [newPw, setNewPw] = useState<PasswordState>({ password: '', isShow: false })
+  const [checkPw, setCheckPw] = useState<PasswordState>({ password: '', isShow: false })
+
+  const [isValid, setIsValid] = useState<boolean>(true)
+  const [isSame, setIsSame] = useState<boolean>(true)
+
+  const session: any = useSession()
+
+  const onChangeNewPw: ChangeEventHandler<HTMLInputElement> = e => {
+    setNewPw(prev => ({ ...prev, password: e.target.value }))
+
+    if (isValidPassword(newPw.password)) setIsValid(true)
+  }
+
+  const onBlurNewPw: ChangeEventHandler<HTMLInputElement> = e => {
+    if (isValidPassword(newPw.password)) setIsValid(true)
+    else setIsValid(false)
+  }
+
+  const onChangeCheckPw: ChangeEventHandler<HTMLInputElement> = e => {
+    setCheckPw(prev => ({ ...prev, password: e.target.value }))
+
+    if (newPw.password === e.target.value) setIsSame(true)
+    else setIsSame(false)
+  }
+
+  const onClickPwChange = async () => {
+    if (newPw.password.trim() === '') {
+      alert('새 비밀번호를 입력해주세요.')
+      return
+    }
+    if (!isValid) {
+      alert('새 비밀번호 형식이 올바르지 않습니다.')
+      return
+    }
+    if (!isSame) {
+      alert('비밀번호 확인을 다시 입력해주세요.')
+      return
+    }
+
+    try {
+      const res = await fetch(`/server/${BACKEND_ROUTES.AUTH.UPDATE_PASSWORD.url}`, {
+        method: BACKEND_ROUTES.AUTH.UPDATE_PASSWORD.method,
+        headers: {
+          Authorization: session.data.accessToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          password: currentPw.password,
+          newPassword: newPw.password,
+        }),
+        credentials: 'include',
+      })
+
+      const status = res.status
+      const data = await res.json()
+      console.log(data)
+
+      switch (status) {
+        case 200:
+          alert('비밀번호 변경이 완료되었습니다.')
+          return
+        case 400:
+          alert('현재 비밀번호가 다릅니다.')
+          break
+        default:
+          alert('다시 시도해주세요.')
+          break
+      }
+    } catch (error) {
+      alert('비밀번호 변경이 실패하였습니다.')
+    }
+  }
+
+  const renderEye = (pw: PasswordState, setPw: Dispatch<SetStateAction<PasswordState>>) => {
+    return (
+      <LucideIcon
+        name={!pw.isShow ? 'EyeOff' : 'Eye'}
+        onClick={() => setPw(prev => ({ ...prev, isShow: !pw.isShow }))}
+        className='absolute right-2 h-full opacity-40'
+        size={24}
+      />
+    )
+  }
+
+  return (
+    <div className='flex w-full flex-col bg-white px-10'>
+      <div className='flex w-full flex-col items-start justify-end gap-4'>
+        <span className='flex h-[8dvh] min-h-[60px] items-end text-2xl font-semibold xl:text-3xl'>내 정보 관리</span>
+        <span className='border-b border-solid border-black text-sm font-medium xl:text-base'>비밀번호 변경</span>
+      </div>
+
+      <div className='mt-9 flex grow flex-col items-center gap-8'>
+        <div className='flex w-full max-w-[300px] flex-col'>
+          <Label htmlFor='currentPw' className='mb-2 flex text-base'>
+            현재 비밀번호 <span className='text-tbRed'>*</span>
+          </Label>
+          <div className='gap relative flex justify-between gap-2'>
+            <Input
+              onChange={e => setCurrentPw(prev => ({ ...prev, password: e.target.value }))}
+              // onBlur={onBlurPassword}
+              type={currentPw.isShow ? 'text' : 'password'}
+              id='currentPw'
+              placeholder=''
+              className={cn('h-13 bg-tbPlaceholder shadow-tb-shadow', false && 'ring-2 ring-tbRed')}
+            />
+            {renderEye(currentPw, setCurrentPw)}
+          </div>
+        </div>
+
+        <div className='flex w-full max-w-[300px] flex-col'>
+          <Label htmlFor='newPw' className='mb-2 flex text-base'>
+            비밀번호 <span className='text-tbRed'>*</span>
+          </Label>
+          <div className='gap relative flex justify-between gap-2'>
+            <Input
+              onChange={onChangeNewPw}
+              onBlur={onBlurNewPw}
+              type={newPw.isShow ? 'text' : 'password'}
+              id='newPw'
+              placeholder=''
+              className={cn('h-13 bg-tbPlaceholder shadow-tb-shadow', !isValid && 'ring-2 ring-tbRed')}
+            />
+            {renderEye(newPw, setNewPw)}
+          </div>
+          <p className={cn(isValid ? 'invisible text-sm' : 'mt-1 pl-2 text-sm text-tbRed')}>
+            * 올바른 형식이 아닙니다.
+          </p>
+        </div>
+
+        <div className='text-center text-sm text-slate-500'>
+          안전한 비밀번호를 위해
+          <br />
+          영문자, 숫자, 특수문자를 포함해야 합니다.
+        </div>
+
+        <div className='flex w-full max-w-[300px] flex-col'>
+          <Label htmlFor='checkPw' className='mb-2 flex text-base'>
+            비밀번호 확인<span className='text-tbRed'>*</span>
+          </Label>
+          <div className='gap relative flex justify-between gap-2'>
+            <Input
+              onChange={onChangeCheckPw}
+              type={checkPw.isShow ? 'text' : 'password'}
+              id='checkPw'
+              placeholder=''
+              className={cn('h-13 bg-tbPlaceholder shadow-tb-shadow', !isSame && 'ring-2 ring-tbRed')}
+            />
+            {renderEye(checkPw, setCheckPw)}
+          </div>
+          <p className={cn(isSame ? 'invisible text-sm' : 'mt-1 pl-2 text-sm text-tbRed')}>
+            * 비밀번호를 확인해주세요.
+          </p>
+        </div>
+
+        <Button onClick={onClickPwChange} variant='tbPrimary' className='mt-3 h-13 w-full max-w-[300px]'>
+          비밀번호 변경
+        </Button>
+      </div>
+
+      <div className='my-3 flex flex-col text-center text-[#817A7A] md:block'>
+        더 이상 TRABOOK과 함께하고 싶지 않으신가요?
+        <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
+          회원 탈퇴
+        </Link>
+      </div>
+    </div>
+  )
 }
 
 export default ChangePasswordPage

--- a/app/(route)/(header)/main/password/page.tsx
+++ b/app/(route)/(header)/main/password/page.tsx
@@ -1,0 +1,9 @@
+import React, { ReactNode } from 'react'
+
+interface ChangePasswordPageProps {}
+
+const ChangePasswordPage = ({}: ChangePasswordPageProps): ReactNode => {
+  return <div className='w-full bg-white'>ChangePasswordPage</div>
+}
+
+export default ChangePasswordPage

--- a/auth.ts
+++ b/auth.ts
@@ -68,12 +68,16 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           const status = res.status
           const data = await res.json()
           console.log(data)
+          console.log(res.headers)
 
           switch (status) {
             case 200:
               // accessToken to session
               user.accessToken = res.headers.get('Authorization')
               user.userId = data.userId
+              user.nickname = data.username
+              user.status_message = data.status_message
+              user.image = data.image
               break
             case 404:
               console.log(data.message)
@@ -116,6 +120,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               // accessToken to session
               user.accessToken = res.headers.get('Authorization')
               user.userId = data.userId
+              user.nickname = data.username
+              user.status_message = data.status_message
+              user.image = data.image
               break
             case 400:
               console.log(data.message)
@@ -156,6 +163,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               // accessToken to session
               user.accessToken = res.headers.get('Authorization')
               user.userId = data.userId
+              user.nickname = data.username
+              user.status_message = data.status_message
+              user.image = data.image
               break
             case 400:
               console.log(data.message)
@@ -200,6 +210,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.userId = user.userId
         token.image = user.image
         token.status_message = user.status_message
+        token.nickname = user.nickname
       }
 
       // console.log('user', user)
@@ -214,6 +225,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       session.userId = token.userId
       session.image = token.image
       session.status_message = token.status_message
+      session.nickname = token.nickname
 
       delete session.user
 

--- a/auth.ts
+++ b/auth.ts
@@ -67,8 +67,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
           const status = res.status
           const data = await res.json()
-          console.log(data)
-          console.log(res.headers)
+          // console.log(data)
+          // console.log(res.headers)
 
           switch (status) {
             case 200:
@@ -112,7 +112,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
           const status = res.status
           const data = await res.json()
-          console.log(data)
+          // console.log(data)
 
           switch (status) {
             case 200:
@@ -168,7 +168,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               user.image = data.image
               break
             case 400:
-              console.log(data.message)
+              // console.log(data.message)
               return 'error'
               break
             default:

--- a/auth.ts
+++ b/auth.ts
@@ -67,7 +67,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
           const status = res.status
           const data = await res.json()
-          console.log(data, data)
+          console.log(data)
 
           switch (status) {
             case 200:
@@ -108,6 +108,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
           const status = res.status
           const data = await res.json()
+          console.log(data)
 
           switch (status) {
             case 200:
@@ -185,12 +186,23 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
       return `${baseUrl}/`
     },
-    jwt: async ({ token, user }: { token: any; user: any }) => {
+    jwt: async ({ token, user, trigger, session }: { token: any; user: any; trigger?: string; session?: any }) => {
+      if (trigger === 'update' && session !== null) {
+        return {
+          ...token,
+          ...session,
+        }
+      }
+
       if (user) {
         token.accessToken = user.accessToken
         token.provider = user.provider
         token.userId = user.userId
+        token.image = user.image
+        token.status_message = user.status_message
       }
+
+      // console.log('user', user)
 
       // console.log('jwt', token)
 
@@ -200,6 +212,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       session.accessToken = token.accessToken
       session.provider = token.provider
       session.userId = token.userId
+      session.image = token.image
+      session.status_message = token.status_message
 
       delete session.user
 

--- a/auth.ts
+++ b/auth.ts
@@ -44,8 +44,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   ],
   callbacks: {
     signIn: async ({ user, account }: { user: any; account: any }) => {
-      console.log('account', account)
-      console.log('user', user)
+      // console.log('account', account)
+      // console.log('user', user)
 
       user.provider = account.provider
 
@@ -192,7 +192,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.userId = user.userId
       }
 
-      console.log('jwt', token)
+      // console.log('jwt', token)
 
       return token
     },
@@ -203,7 +203,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
       delete session.user
 
-      console.log('session', session)
+      // console.log('session', session)
 
       return session
     },

--- a/components/Header/MobileMenu.tsx
+++ b/components/Header/MobileMenu.tsx
@@ -45,13 +45,23 @@ const COMMUNITY_SECTION: NavSection = {
     { name: '동행 모집', url: ROUTES.COMMUNITY.COMPANION.url },
   ],
 }
-const MY_SECTION: NavSection = {
+
+const MY_SECTION_SOCIAL: NavSection = {
   title: 'MY',
-  sections: [{ name: '내 정보', url: ROUTES.MAIN.INFO.url }],
+  sections: [{ name: '프로필 변경', url: ROUTES.MAIN.INFO.url }],
+}
+
+const MY_SECTION_CREDENTIALS: NavSection = {
+  title: 'MY',
+  sections: [
+    { name: '프로필 변경', url: ROUTES.MAIN.INFO.url },
+    { name: '비밀번호 변경', url: ROUTES.MAIN.CHANGE_PASSWORD.url },
+  ],
 }
 
 const MobileMenu = ({ session, className }: MobileMenuProps): ReactNode => {
   const { ref, isOpen, toggleDropdown } = useDropdown() // 드롭다운 상태 관리
+  const s: any = session
 
   /**
    * 각 Session 상수에 대한 Link를 렌더링합니다
@@ -99,7 +109,7 @@ const MobileMenu = ({ session, className }: MobileMenuProps): ReactNode => {
 
         {renderNavLinks(COMMUNITY_SECTION)}
         <Divider />
-        {renderNavLinks(MY_SECTION)}
+        {s?.provider === 'credentials' ? renderNavLinks(MY_SECTION_CREDENTIALS) : renderNavLinks(MY_SECTION_SOCIAL)}
       </ToggleWrapper>
     </>
   )

--- a/components/auth/EmailCheck.tsx
+++ b/components/auth/EmailCheck.tsx
@@ -90,8 +90,6 @@ const EmailCheck = ({ setIsNext, email, setEmail }: EmailCheckProps): ReactNode 
     }
 
     try {
-      console.log(email, code)
-
       const res = await fetch(`server/${BACKEND_ROUTES.AUTH.VERIFY_CODE.url}`, {
         method: BACKEND_ROUTES.AUTH.VERIFY_CODE.method,
         headers: {
@@ -105,8 +103,6 @@ const EmailCheck = ({ setIsNext, email, setEmail }: EmailCheckProps): ReactNode 
       })
 
       const status = res.status
-
-      console.log(status)
 
       switch (status) {
         case 200:

--- a/components/main/ProfileChange.tsx
+++ b/components/main/ProfileChange.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import React, { ReactNode, useState } from 'react'
 
@@ -43,9 +44,8 @@ const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
   const [image, setImage] = useState<File | string | undefined>()
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const { update } = useSession()
-  console.log(session)
 
-  // console.log(session)
+  const router = useRouter()
 
   const onClickImage = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -100,17 +100,18 @@ const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
 
       const status = res.status
       const data = await res.json()
-      console.log(data)
 
       switch (status) {
         case 200:
-          update({ nickname: nickname, status_message: message, image: data.profilePhoto })
+          await update({ nickname: nickname, status_message: message, image: data.profilePhoto })
           alert('변경이 완료되었습니다.')
+          router.refresh()
           return
         case 500:
           alert('다시 시도해주세요.')
           break
         default:
+          alert('다시 시도해주세요.')
           break
       }
     } catch (error) {
@@ -184,7 +185,10 @@ const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
 
       <div className='my-3 flex flex-col text-center text-sm text-[#817A7A] md:block'>
         더 이상 TRABOOK과 함께하고 싶지 않으신가요?
-        <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
+        <Link
+          href={ROUTES.AUTH.SIGNOUT.url}
+          className='mx-5 text-black underline hover:cursor-pointer hover:text-tbBlue'
+        >
           회원 탈퇴
         </Link>
       </div>

--- a/components/main/ProfileChange.tsx
+++ b/components/main/ProfileChange.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useSession } from 'next-auth/react'
+import React, { ReactNode, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { BACKEND_ROUTES, ROUTES } from '@/lib/constants/routes'
+import LucideIcon from '@/lib/icons/LucideIcon'
+import { UserInfo } from '@/lib/types/Session'
+import ProfileImage from '@/public/dummy/dummy_profile_image.png'
+
+function validateNickname(nickname: string) {
+  // 정규 표현식: 영문자, 한글, 숫자만 허용
+  const regex = /^[a-zA-Z가-힣0-9]+$/
+
+  return regex.test(nickname)
+}
+
+interface ProfileChangeProps {
+  session: UserInfo
+}
+
+function validateProfileMessage(message: string): boolean {
+  const maxLength = 30
+
+  // 허용할 문자 (영문, 한글, 숫자, 기본 특수 문자)
+  const allowedCharacters = /^[a-zA-Z0-9가-힣\s.,!?()&-~]*$/
+
+  if (message.length > maxLength || !allowedCharacters.test(message)) {
+    return false
+  }
+
+  return true
+}
+
+// placeholder 추가 필요 -> 완
+// auth.ts -> session 내용 추가하기 -> 완
+
+// 모바일 헤더 바꾸기
+// 코드 깔끔하게
+// 변경되지 않았으면 원래 값을 넣어야됨 -> 완
+// 사이드바 에러 -> 완
+// 이미지 삭제 기능 없음
+
+const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
+  const [nickname, setNickname] = useState<string>(session.nickname)
+  const [message, setMessage] = useState<string>(session.status_message || '')
+  const [image, setImage] = useState<File | string | undefined>()
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const { update } = useSession()
+  console.log(session)
+
+  // console.log(session)
+
+  const onClickImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setImage(file)
+
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setPreviewUrl(reader.result as string)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const onClickButton = async () => {
+    // 닉네임 validation
+    const username: string = nickname.trim()
+    if (username.length < 2) {
+      alert('닉네임은 두 글자 이상이어야 합니다.')
+      return
+    }
+    if (!validateNickname(username)) {
+      alert('닉네임은 영문자, 한글, 숫자만 사용 가능합니다.')
+      return
+    }
+    if (!validateProfileMessage(message)) {
+      alert('프로필 메세지는 20자 이하, 영문, 한글, 숫자, 기본 특수 문자만 사용 가능합니다.')
+      return
+    }
+
+    const formData = new FormData()
+
+    if (image) {
+      //image change
+      console.log('이미지 전송하기')
+
+      formData.append('image', image)
+    } else {
+      // image not change, original url
+      session.image && formData.append('imageUrl', session.image)
+    }
+
+    formData.append('username', nickname)
+    formData.append('statusMessage', message)
+
+    // console.log(image)
+
+    // console.log(formData.get('image'))
+
+    try {
+      const res = await fetch(`/server/${BACKEND_ROUTES.AUTH.UPDATE_PROFILE.url}`, {
+        method: BACKEND_ROUTES.AUTH.UPDATE_PROFILE.method,
+        headers: {
+          Authorization: session.accessToken,
+          // 'Content-Type': 'multipart/form-data',
+        },
+        body: formData,
+        credentials: 'include',
+      })
+
+      const status = res.status
+      const data = await res.json()
+      console.log(data)
+
+      switch (status) {
+        case 200:
+          update({ nickname: nickname, status_message: message, image: data.profilePhoto })
+          alert('변경이 완료되었습니다.')
+          return
+        case 500:
+          alert('다시 시도해주세요.')
+          break
+        default:
+          break
+      }
+    } catch (error) {
+      alert('프로필 변경이 실패하였습니다.')
+    }
+  }
+
+  return (
+    <div className='relative flex w-full flex-col bg-white px-10'>
+      <div className='flex w-full flex-col items-start justify-end gap-4'>
+        <span className='flex h-[8dvh] min-h-[60px] items-end text-2xl font-semibold xl:text-3xl'>내 정보 관리</span>
+        <span className='border-b border-solid border-black text-sm font-medium xl:text-base'>프로필 수정</span>
+      </div>
+
+      <div className='grow md:flex md:w-2/3'>
+        <div className='mt-10 flex grow flex-col items-center'>
+          <Label htmlFor='image' className='hover:cursor-pointer'>
+            <Image
+              alt='프로필 이미지'
+              src={previewUrl || session.image || ProfileImage}
+              className='aspect-square h-[120px] w-[120px] rounded-full lg:h-[150px] lg:w-[150px]'
+              width={150}
+              height={150}
+            />
+            <div className='mt-2 text-center text-base'>프로필 사진</div>
+          </Label>
+          <Input id='image' type='file' className='hidden' onChange={onClickImage} />
+        </div>
+
+        <div className='mt-9 flex grow flex-col items-center gap-8'>
+          <div className='flex w-full max-w-[300px] flex-col'>
+            <Label htmlFor='nickname' className='mb-2 flex text-base'>
+              닉네임 <span className='text-tbRed'>*</span>
+            </Label>
+            <Input
+              onChange={e => setNickname(e.target.value)}
+              className='h-13'
+              placeholder={session.nickname}
+              id='nickname'
+              type='text'
+              value={nickname}
+            />
+          </div>
+
+          <div className='w-full max-w-[300px]'>
+            <Label htmlFor='email' className='mb-2 flex items-center text-base'>
+              이메일 <LucideIcon name='Info' className='ml-2' id='email' />
+            </Label>
+            <Input className='h-13' placeholder={session.email} disabled />
+          </div>
+
+          <div className='flex w-full max-w-[300px] flex-col'>
+            <Label htmlFor='message' className='mb-2 text-base'>
+              상태 메세지 <span className='text-tbRed'>*</span>
+            </Label>
+            <Input
+              onChange={e => setMessage(e.target.value)}
+              className='h-13'
+              placeholder={session.status_message}
+              id='message'
+              type='text'
+              value={message}
+            />
+          </div>
+
+          <Button onClick={onClickButton} variant='tbPrimary' className='mt-3 h-13 w-full max-w-[300px]'>
+            프로필 저장
+          </Button>
+        </div>
+      </div>
+
+      <div className='my-3 flex flex-col text-center text-[#817A7A] md:block'>
+        더 이상 TRABOOK과 함께하고 싶지 않으신가요?
+        <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
+          회원 탈퇴
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default ProfileChange

--- a/components/main/ProfileChange.tsx
+++ b/components/main/ProfileChange.tsx
@@ -37,15 +37,6 @@ function validateProfileMessage(message: string): boolean {
   return true
 }
 
-// placeholder 추가 필요 -> 완
-// auth.ts -> session 내용 추가하기 -> 완
-
-// 모바일 헤더 바꾸기
-// 코드 깔끔하게
-// 변경되지 않았으면 원래 값을 넣어야됨 -> 완
-// 사이드바 에러 -> 완
-// 이미지 삭제 기능 없음
-
 const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
   const [nickname, setNickname] = useState<string>(session.nickname)
   const [message, setMessage] = useState<string>(session.status_message || '')
@@ -86,23 +77,15 @@ const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
     }
 
     const formData = new FormData()
-
     if (image) {
       //image change
-      console.log('이미지 전송하기')
-
       formData.append('image', image)
     } else {
       // image not change, original url
       session.image && formData.append('imageUrl', session.image)
     }
-
     formData.append('username', nickname)
     formData.append('statusMessage', message)
-
-    // console.log(image)
-
-    // console.log(formData.get('image'))
 
     try {
       const res = await fetch(`/server/${BACKEND_ROUTES.AUTH.UPDATE_PROFILE.url}`, {
@@ -199,7 +182,7 @@ const ProfileChange = ({ session }: ProfileChangeProps): ReactNode => {
         </div>
       </div>
 
-      <div className='my-3 flex flex-col text-center text-[#817A7A] md:block'>
+      <div className='my-3 flex flex-col text-center text-sm text-[#817A7A] md:block'>
         더 이상 TRABOOK과 함께하고 싶지 않으신가요?
         <Link href={ROUTES.AUTH.SIGNOUT.url} className='mx-5 text-black underline hover:cursor-pointer'>
           회원 탈퇴

--- a/components/main/SideBar.tsx
+++ b/components/main/SideBar.tsx
@@ -11,6 +11,9 @@ import ProfileImage from '@/public/dummy/dummy_profile_image.png'
 
 interface SideBarProps {
   isCredentails: boolean
+  image: string | undefined
+  status_message: string | undefined
+  nickname: string
 }
 
 // Dummy Data
@@ -21,7 +24,7 @@ const dummy_user = {
   statusMessage: '좋은 사람과 가는 좋은 여행',
 }
 
-const SideBar = ({ isCredentails }: SideBarProps): ReactNode => {
+const SideBar = ({ isCredentails, image, status_message, nickname }: SideBarProps): ReactNode => {
   const pathname = usePathname()
 
   return (
@@ -29,9 +32,15 @@ const SideBar = ({ isCredentails }: SideBarProps): ReactNode => {
     <div className='min-h-screen-header relative hidden h-auto w-1/6 min-w-[140px] max-w-[200px] flex-col items-center justify-start md:flex'>
       {/* 프로필 */}
       <div className='flex w-full flex-col items-center justify-start border-b border-solid border-tbGray py-7'>
-        <Image alt='프로필 이미지' src={dummy_user.imageSrc} className='aspect-square w-2/5 rounded-full' />
-        <div className='py-3 text-lg font-semibold'>{dummy_user.name}</div>
-        <div className='text-pretty text-center text-sm font-medium'>{dummy_user.statusMessage}</div>
+        <Image
+          alt='프로필 이미지'
+          src={image || ProfileImage}
+          className='aspect-square w-2/5 rounded-full'
+          width={80}
+          height={80}
+        />
+        <div className='py-3 text-lg font-semibold'>{nickname}</div>
+        <div className='text-pretty text-center text-sm font-medium'>{status_message}</div>
       </div>
       {/* 링크 */}
       <div className='flex w-3/4 flex-col items-start justify-start gap-8 py-10 text-xl font-medium 2xl:text-2xl'>

--- a/components/main/SideBar.tsx
+++ b/components/main/SideBar.tsx
@@ -9,7 +9,9 @@ import LucideIcon from '@/lib/icons/LucideIcon'
 import { cn } from '@/lib/utils/cn'
 import ProfileImage from '@/public/dummy/dummy_profile_image.png'
 
-interface SideBarProps {}
+interface SideBarProps {
+  isCredentails: boolean
+}
 
 // Dummy Data
 // Todo: 로그인 성공 후 실제 데이터로 교체 (Frontend Entity Type 교체)
@@ -19,7 +21,7 @@ const dummy_user = {
   statusMessage: '좋은 사람과 가는 좋은 여행',
 }
 
-const SideBar = ({}: SideBarProps): ReactNode => {
+const SideBar = ({ isCredentails }: SideBarProps): ReactNode => {
   const pathname = usePathname()
 
   return (
@@ -32,12 +34,13 @@ const SideBar = ({}: SideBarProps): ReactNode => {
         <div className='text-pretty text-center text-sm font-medium'>{dummy_user.statusMessage}</div>
       </div>
       {/* 링크 */}
-      <div className='flex w-full flex-col items-center justify-start gap-8 py-10 text-xl font-medium 2xl:text-2xl'>
+      <div className='flex w-2/3 flex-col items-start justify-start gap-8 py-10 text-xl font-medium 2xl:text-2xl'>
         <Link href={ROUTES.MAIN.MY_PLAN.url} className='flex items-center justify-center gap-4'>
           <LucideIcon name='Plane' size={26} strokeWidth={1.5} />
           <span className={cn('hover:text-tbRed', pathname === '/main' && 'font-semibold text-tbRed')}>내 계획</span>
         </Link>
-        <div className='flex w-full items-start justify-center gap-4'>
+
+        <div className='flex w-full items-start justify-start gap-4'>
           <LucideIcon name='Bookmark' size={26} strokeWidth={1.5} />
           <div className='flex flex-col items-start justify-start gap-2'>
             <Link href={ROUTES.MAIN.STORE_PLAN.url}>보관함</Link>
@@ -61,12 +64,33 @@ const SideBar = ({}: SideBarProps): ReactNode => {
             </Link>
           </div>
         </div>
-        <Link href={ROUTES.MAIN.INFO.url} className='flex items-center justify-center gap-4'>
+
+        <div className='flex w-full items-start justify-start gap-4'>
           <LucideIcon name='Settings' size={26} strokeWidth={1.5} />
-          <span className={cn('hover:text-tbRed', pathname.includes('info') && 'font-semibold text-tbRed')}>
-            내 정보
-          </span>
-        </Link>
+          <div className='flex flex-col items-start justify-start gap-2'>
+            <Link href={ROUTES.MAIN.INFO.url}>내 정보</Link>
+            <Link
+              href={ROUTES.MAIN.INFO.url}
+              className={cn(
+                'text-base hover:text-tbRed 2xl:text-lg',
+                pathname.includes('info') && 'font-semibold text-tbRed',
+              )}
+            >
+              프로필 수정
+            </Link>
+            {isCredentails && (
+              <Link
+                href={ROUTES.MAIN.CHANGE_PASSWORD.url}
+                className={cn(
+                  'text-base hover:text-tbRed 2xl:text-lg',
+                  pathname.includes('password') && 'font-semibold text-tbRed',
+                )}
+              >
+                비밀번호 변경
+              </Link>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/components/main/SideBar.tsx
+++ b/components/main/SideBar.tsx
@@ -34,7 +34,7 @@ const SideBar = ({ isCredentails }: SideBarProps): ReactNode => {
         <div className='text-pretty text-center text-sm font-medium'>{dummy_user.statusMessage}</div>
       </div>
       {/* 링크 */}
-      <div className='flex w-2/3 flex-col items-start justify-start gap-8 py-10 text-xl font-medium 2xl:text-2xl'>
+      <div className='flex w-3/4 flex-col items-start justify-start gap-8 py-10 text-xl font-medium 2xl:text-2xl'>
         <Link href={ROUTES.MAIN.MY_PLAN.url} className='flex items-center justify-center gap-4'>
           <LucideIcon name='Plane' size={26} strokeWidth={1.5} />
           <span className={cn('hover:text-tbRed', pathname === '/main' && 'font-semibold text-tbRed')}>내 계획</span>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
     <input
       type={type}
       className={cn(
-        'flex h-10 w-full rounded-md border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        'flex h-10 w-full rounded-md border-input bg-tbPlaceholder px-3 py-2 text-sm shadow-tb-shadow ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       ref={ref}

--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -51,6 +51,10 @@ export const ROUTES = {
       name: '내 정보',
       url: '/main/info',
     },
+    CHANGE_PASSWORD: {
+      name: '비밀번호 변경',
+      url: '/main/password',
+    },
   },
   PLAN: {
     name: '여행 계획하기',

--- a/lib/types/Session.ts
+++ b/lib/types/Session.ts
@@ -1,0 +1,8 @@
+export interface UserInfo {
+  email: string
+  accessToken: string
+  provider: string
+  status_message: string | undefined
+  image: string | undefined
+  nickname: string
+}

--- a/lib/types/Session.ts
+++ b/lib/types/Session.ts
@@ -1,7 +1,7 @@
 export interface UserInfo {
   email: string
   accessToken: string
-  provider: string
+  provider: 'credentials' | 'kakao' | 'google' | 'naver'
   status_message: string | undefined
   image: string | undefined
   nickname: string

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+      },
+    ],
+  },
   async rewrites() {
     return [
       {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,10 @@ const config = {
       },
     },
     extend: {
+      flexGrow: {
+        2: '2',
+        3: '3',
+      },
       width: {
         '102': '28rem',
       },


### PR DESCRIPTION
### 기능
1. 프로필 수정 - 닉네임, 상태 메시지, 프로필 이미지
2. 비밀번호 변경

### 수정 사항
1. 사이드 바 - 이메일 로그인일 때만 '비밀변호 변경' 항목이 보입니다.
<img width="180" alt="스크린샷 2024-09-08 오후 5 39 41" src="https://github.com/user-attachments/assets/1ede0eab-4269-47af-80c9-8815b6a9e3fc">

2. 모바일 메뉴 - 'MY' 밑에 프로필 변경이 추가되었습니다. 이메일 로그인일 때만 '비밀변호 변경'항목이 보입니다.
<img width="197" alt="스크린샷 2024-09-08 오후 5 31 35" src="https://github.com/user-attachments/assets/0ceb3196-6fd0-49f5-8ef7-4b35970da102">

### Session
image(프로필 사진 url), profile_message(상태 메세지), provider(로그인 방식)이 추가되었습니다.
provider를 추가해서 credentials(이메일) 로그인 일때만 '비밀번호 변경'항목이 보이도록 하였습니다.
type을 아직 설정해두지 않아서 any 타입을 사용하였습니다.

### 추가되어야할 기능
1. 비밀번호 찾기
2. 프로필 이미지 삭제(초기화)