### PR TITLE
feat: 여행지 간의 이동거리 계산

### DIFF
--- a/lib/utils/duration.ts
+++ b/lib/utils/duration.ts
@@ -1,0 +1,51 @@
+const KAKAO_MOBILITY_URL = 'https://apis-navi.kakaomobility.com/v1/directions'
+
+type Place = {
+  x: string
+  y: string
+}
+
+export const getDuration = async (start: Place, end: Place) => {
+  const origin = `${start.x},${start.y}`
+  const destination = `${end.x},${end.y}`
+  const priority = 'RECOMMEND'
+  const url = `${KAKAO_MOBILITY_URL}?origin=${origin}&destination=${destination}&priority=${priority}`
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_REST_API}`,
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    })
+
+    const data = await res.json()
+
+    if (res.ok) {
+      return Math.floor(data.routes[0].summary.duration / 60)
+    } else {
+      return { message: 'fetch failed' }
+    }
+  } catch (error) {
+    return { message: 'fetch error' }
+  }
+}
+
+// 판교역
+const dummy1: Place = {
+  x: '127.11015314141542',
+  y: '37.394912',
+}
+
+// 강남역
+const dummy2: Place = {
+  x: '127.028361548',
+  y: '37.496486063',
+}
+
+export const testDuration = async () => {
+  const result = await getDuration(dummy1, dummy2)
+  return result
+}


### PR DESCRIPTION
### 두 여행지 사이의 이동 시간을 구하는 함수를 만들었습니다
- 카카오 모빌리티 API를 사용했습니다.
- 자동차 이동거리입니다.
- 카카오의 추천 경로에 대한 시간입니다.

### 사용법
- 코드에 더미 데이터로 만든 예시가 있습니다.
- 어렵지 않아서 참고하고 사용하시면 될 것 같아요.

### 주의
- 무료 사용은 하루에 10000번입니다!! 유의해주세요...